### PR TITLE
Make PRs clickable in release notes

### DIFF
--- a/game_ff12.py
+++ b/game_ff12.py
@@ -1,7 +1,7 @@
 import mobase
 VERSION_MAJOR = 0
 VERSION_MINOR = 5
-VERSION_PATCH = 1
+VERSION_PATCH = 2
 VERSION_RELEASE_TYPE = mobase.ReleaseType.BETA
 import shutil
 import os


### PR DESCRIPTION
Replaces PR numbers with links to actual PRs in release notes in updater.