### PR TITLE
Remove commit count from release template

### DIFF
--- a/.github/changelog-config.json
+++ b/.github/changelog-config.json
@@ -1,6 +1,6 @@
 {
   "template": "${{CHANGELOG}}\n",
-  "pr_template": "- ${{TITLE}} (#${{NUMBER}})\n  Commits: ${{COMMITS}}\n",
+  "pr_template": "- ${{TITLE}} (#${{NUMBER}})\n",
   "commit_template": "    - ${{COMMIT_MESSAGE}} [${{COMMIT_SHA}}](${{COMMIT_URL}})",
   "categories": [
     {


### PR DESCRIPTION
Commit count is per release, not per PR, so it was the same for all PRs and rather pointless.