### PR TITLE
Add Archives Tab

### DIFF
--- a/ff12/Archive/Loader.py
+++ b/ff12/Archive/Loader.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+from PyQt6.QtCore import QThread, pyqtSignal
+
+from .Reader import ArchiveReader
+
+class ArchiveLoader(QThread):
+    """Background thread for loading archive."""
+    finished = pyqtSignal(object)
+    error = pyqtSignal(str)
+
+    def __init__(self, archive_path: Path):
+        super().__init__()
+        self._archive_path = archive_path
+
+    def run(self):
+        """Load archive in background thread."""
+        try:
+            reader = ArchiveReader(self._archive_path)
+            self.finished.emit(reader)
+        except Exception as e:
+            self.error.emit(str(e))

--- a/ff12/Archive/Model.py
+++ b/ff12/Archive/Model.py
@@ -1,0 +1,271 @@
+from enum import IntEnum, auto
+from pathlib import Path
+
+from PyQt6.QtCore import QAbstractItemModel, QFileInfo, QModelIndex, Qt
+from PyQt6.QtWidgets import QFileIconProvider
+
+from .Reader import ArchiveReader
+
+class TreeNode:
+    def __init__(self, name: str, parent = None, is_dir = False, size = 0, entry = None):
+        self.name = name
+        self.parent = parent
+        self.is_dir = is_dir
+        self.size = size
+        self.children = []
+        self.entry = entry
+
+        if parent:
+            parent.children.append(self)
+
+    def child_count(self) -> int:
+        return len(self.children)
+
+    def child(self, row: int) -> 'TreeNode | None':
+        if 0 <= row < len(self.children):
+            return self.children[row]
+        return None
+
+    def row(self) -> int:
+        if self.parent:
+            return self.parent.children.index(self)
+        return 0
+
+    def path(self) -> str:
+        """Get the full path to this node."""
+        if self.parent and self.parent.parent:
+            return self.parent.path() + "/" + self.name
+        return self.name
+
+    def sort_children(self, column: int, order: Qt.SortOrder):
+        """Sort children by the specified column and order.
+        Directories always come before files.
+        Directories only reorder when column == NAME.
+        """
+        dirs = [i for i in self.children if i.is_dir]
+        if column == ArchiveColumn.NAME:
+            dirs.sort(key=lambda node: node.name.lower(),
+                    reverse=(order == Qt.SortOrder.DescendingOrder))
+
+        files = [i for i in self.children if not i.is_dir]
+        if column == ArchiveColumn.NAME:
+            files.sort(key=lambda node: node.name.lower(),
+                    reverse=(order == Qt.SortOrder.DescendingOrder))
+        elif column == ArchiveColumn.TYPE:
+            files.sort(key=lambda node: QFileInfo(node.name).suffix().lower(),
+                    reverse=(order == Qt.SortOrder.DescendingOrder))
+        elif column == ArchiveColumn.SIZE:
+            files.sort(key=lambda node: node.size,
+                    reverse=(order == Qt.SortOrder.DescendingOrder))
+
+        self.children = dirs + files
+        for i in dirs:
+            i.sort_children(column, order)
+
+class ArchiveColumn(IntEnum):
+    NAME = 0
+    TYPE = auto()
+    SIZE = auto()
+
+class ArchiveModel(QAbstractItemModel):
+    def __init__(self, parent = None):
+        super().__init__(parent)
+        self._reader = None
+        self._icon_provider = QFileIconProvider()
+        self._root_node = TreeNode("", None, True)
+        self._sort_column = ArchiveColumn.NAME
+        self._sort_order = Qt.SortOrder.AscendingOrder
+
+    def set_data(self, reader: ArchiveReader):
+        self.beginResetModel()
+        self._reader = reader
+        self._build_tree()
+        self._sort_tree()
+        self.endResetModel()
+
+    def _build_tree(self):
+        """Build the tree structure from archive entries."""
+        dir_nodes: dict[str, TreeNode] = {"": self._root_node}
+        sorted_entries = sorted(self._reader._entries.items(), key = lambda x: x[0])
+
+        for name, entry in sorted_entries:
+            path_parts = name.split('/')
+            current_path = ""
+            current_node = self._root_node
+
+            for i, part in enumerate(path_parts[:-1]):
+                if current_path:
+                    current_path += "/" + part
+                else:
+                    current_path = part
+
+                if current_path not in dir_nodes:
+                    dir_node = TreeNode(part, current_node, True)
+                    dir_nodes[current_path] = dir_node
+                    current_node = dir_node
+                else:
+                    current_node = dir_nodes[current_path]
+
+            filename = path_parts[-1]
+            file_node = TreeNode(filename, current_node, False, entry.original_size, entry)
+
+    def _sort_tree(self):
+        """Sort the entire tree."""
+        self._root_node.sort_children(self._sort_column, self._sort_order)
+
+    def sort(self, column: int, order: Qt.SortOrder):
+        """Implement sorting with proper persistent index handling"""
+        persistent_indexes = self.persistentIndexList()
+
+        old_nodes = []
+        for index in persistent_indexes:
+            if index.isValid():
+                old_nodes.append(index.internalPointer())
+            else:
+                old_nodes.append(None)
+
+        self.layoutAboutToBeChanged.emit([], QAbstractItemModel.LayoutChangeHint.VerticalSortHint)
+
+        self._sort_column = column
+        self._sort_order = order
+        self._sort_tree()
+
+        new_indexes = []
+        for node in old_nodes:
+            if node is not None:
+                new_index = self._find_index_for_node(node)
+                new_indexes.append(new_index)
+            else:
+                new_indexes.append(QModelIndex())
+
+        for old_index, new_index in zip(persistent_indexes, new_indexes):
+            self.changePersistentIndex(old_index, new_index)
+
+        self.layoutChanged.emit([], QAbstractItemModel.LayoutChangeHint.VerticalSortHint)
+
+    def _find_index_for_node(self, target_node: TreeNode) -> QModelIndex:
+        """Find the QModelIndex for a specific TreeNode after sorting"""
+        if target_node == self._root_node:
+            return QModelIndex()
+
+        path = []
+        current = target_node
+        while current and current != self._root_node:
+            path.append(current)
+            current = current.parent
+
+        current_index = QModelIndex()
+        for node in reversed(path):
+            parent_node = node.parent if node.parent else self._root_node
+            row = parent_node.children.index(node)
+            current_index = self.index(row, 0, current_index)
+
+        return current_index
+
+    def rowCount(self, parent: QModelIndex) -> int:
+        if not parent.isValid():
+            parent_node = self._root_node
+        else:
+            parent_node = parent.internalPointer()
+
+        return parent_node.child_count()
+
+    def columnCount(self, parent: QModelIndex) -> int:
+        return len(ArchiveColumn)
+
+    def index(self, row: int, column: int, parent: QModelIndex) -> QModelIndex:
+        if not self.hasIndex(row, column, parent):
+            return QModelIndex()
+
+        if not parent.isValid():
+            parent_node = self._root_node
+        else:
+            parent_node = parent.internalPointer()
+
+        child_node = parent_node.child(row)
+        if child_node:
+            return self.createIndex(row, column, child_node)
+
+        return QModelIndex()
+
+    def parent(self, index: QModelIndex) -> QModelIndex:
+        if not index.isValid():
+            return QModelIndex()
+
+        child_node = index.internalPointer()
+        parent_node = child_node.parent
+
+        if parent_node == self._root_node or parent_node is None:
+            return QModelIndex()
+
+        return self.createIndex(parent_node.row(), 0, parent_node)
+
+    def data(self, index: QModelIndex, role: int = Qt.ItemDataRole.DisplayRole):
+        if not index.isValid():
+            return None
+
+        node = index.internalPointer()
+        column = index.column()
+
+        if role == Qt.ItemDataRole.DisplayRole:
+            if column == ArchiveColumn.NAME:
+                return node.name
+            elif column == ArchiveColumn.TYPE:
+                if node.is_dir:
+                    return "Folder"
+                else:
+                    file_info = QFileInfo(node.name)
+                    return file_info.suffix()
+            elif column == ArchiveColumn.SIZE:
+                if node.is_dir:
+                    return ""
+                else:
+                    return self._format_file_size(node.size)
+
+        elif role == Qt.ItemDataRole.DecorationRole and column == ArchiveColumn.NAME:
+            if node.is_dir:
+                return self._icon_provider.icon(QFileIconProvider.IconType.Folder)
+            else:
+                file_info = QFileInfo(node.name)
+                return self._icon_provider.icon(file_info)
+
+        return None
+
+    def headerData(self, section: int, orientation: Qt.Orientation, role: int = Qt.ItemDataRole.DisplayRole) -> str | None:
+        if orientation != Qt.Orientation.Horizontal or role != Qt.ItemDataRole.DisplayRole:
+            return None
+
+        match ArchiveColumn(section):
+            case ArchiveColumn.NAME:
+                return "Name"
+            case ArchiveColumn.TYPE:
+                return "Type"
+            case ArchiveColumn.SIZE:
+                return "Size"
+
+        return None
+
+    def get_node(self, index: QModelIndex) -> TreeNode | None:
+        """Get the TreeNode for a given index."""
+        if index.isValid():
+            return index.internalPointer()
+        return None
+
+    @staticmethod
+    def _format_file_size(size: int) -> str:
+        """Format file size (B, KB, MB, GB) with proper fallback."""
+        if size < 1024:
+            return f"{size} B"
+
+        size_f = float(size)
+        for unit in ['KB', 'MB', 'GB']:
+            size_f /= 1024.0
+            if size_f < 1024.0:
+                if size_f < 10:
+                    return f"{size_f:.2f} {unit}"
+                elif size_f < 100:
+                    return f"{size_f:.1f} {unit}"
+                else:
+                    return f"{size_f:.0f} {unit}"
+
+        return f"{size_f:.2f} GB"

--- a/ff12/Archive/Reader.py
+++ b/ff12/Archive/Reader.py
@@ -1,0 +1,188 @@
+import io
+import struct
+import zlib
+
+from pathlib import Path
+from typing import List, Dict, BinaryIO
+
+from PyQt6.QtCore import qWarning
+
+class ArchiveEntry:
+    def __init__(self, original_size: int, data_offset: int, block_sizes: List[int]):
+        self.original_size = original_size
+        self.data_offset = data_offset
+        self.block_sizes = block_sizes
+
+class ArchiveReader:
+    _MAX_BLOCK_SIZE = 64 * 1024
+
+    def __init__(self, path: Path):
+        self._filename = path
+        self._entries: Dict[str, ArchiveEntry] = {}
+        self._file_handle: BinaryIO | None = None
+
+        self._load_metadata()
+
+    def open(self) -> bool:
+        """
+        Open the archive for reading and store the file handle.
+        Returns True if the file was successfully opened or already open, False otherwise.
+        """
+        if self._file_handle is not None:
+            return True
+
+        try:
+            self._file_handle = open(self._filename, "rb")
+            return True
+        except Exception as e:
+            qWarning(f"Failed to open archive: {e}")
+            return False
+
+    def close(self):
+        """Close the file handle."""
+        if self._file_handle is not None:
+            self._file_handle.close()
+            self._file_handle = None
+
+    def __enter__(self):
+        """Enable 'with' statement to automatically open and close the file handle."""
+        self.open()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Enable 'with' statement to automatically open and close the file handle."""
+        self.close()
+
+    def _load_metadata(self):
+        """Load the archive metadata"""
+        with self as file:
+            file = file._file_handle
+            try:
+                header_data = file.read(16)
+                if len(header_data) < 16:
+                    raise EOFError("File too short for header")
+
+                magic, header_size, file_count = struct.unpack("<IIQ", header_data)
+                if magic != 0x4B595253:
+                    raise ValueError("Invalid archive format")
+
+                # Skip MD5 checksums for file names
+                file.seek(16 * file_count, io.SEEK_CUR)
+
+                file_metadata = self._read_file_metadata(file, file_count)
+                file_path_data = self._read_file_path_data(file)
+                block_count = self._get_block_count(file_metadata)
+                global_block_sizes = self._read_block_sizes(file, block_count)
+
+                for block_sizes_start_index, original_size, data_offset, filepath_offset in file_metadata:
+                    name = self._read_null_string_lower(file_path_data, filepath_offset)
+
+                    blocks = original_size // self._MAX_BLOCK_SIZE
+                    if original_size % self._MAX_BLOCK_SIZE != 0:
+                        blocks += 1
+
+                    file_block_sizes = global_block_sizes[block_sizes_start_index:block_sizes_start_index + blocks]
+                    self._entries[name] = ArchiveEntry(original_size, data_offset, file_block_sizes)
+
+            except Exception as e:
+                qWarning(f"Failed to load archive metadata: {e}")
+
+    def _read_file_metadata(self, file: BinaryIO, count: int) -> List[tuple]:
+        """Read metadata for file entries"""
+        file_struct = struct.Struct("<IIQQQ")
+        file_metadata = []
+
+        for _ in range(count):
+            data = file.read(file_struct.size)
+            if len(data) < file_struct.size:
+                raise EOFError("Unexpected EOF reading file metadata")
+
+            block_sizes_start_index, _, original_size, data_offset, filepath_offset = file_struct.unpack(data)
+            file_metadata.append((block_sizes_start_index, original_size, data_offset, filepath_offset))
+
+        return file_metadata
+
+    def _read_file_path_data(self, file: BinaryIO) -> bytes:
+        """Read data for file paths"""
+        size_data = file.read(4)
+        if len(size_data) < 4:
+            raise EOFError("Unexpected EOF reading file path data size")
+
+        size = struct.unpack("<I", size_data)[0]
+        path_data = file.read(size - 4)
+        if len(path_data) < (size - 4):
+            raise EOFError("Unexpected EOF reading file path data")
+
+        return path_data
+
+    def _get_block_count(self, file_metadata: List[tuple]) -> int:
+        """Calculate total number of blocks across all files"""
+        count = 0
+        for _, original_size, _, _ in file_metadata:
+            blocks = original_size // self._MAX_BLOCK_SIZE
+            if original_size % self._MAX_BLOCK_SIZE != 0:
+                blocks += 1
+            count += blocks
+        return count
+
+    def _read_block_sizes(self, file: BinaryIO, count: int) -> List[int]:
+        """Read block sizes for all files"""
+        data = file.read(count * 2)
+        if len(data) < count * 2:
+            raise ValueError("Unexpected EOF reading block sizes")
+
+        return list(struct.unpack(f"<{count}H", data))
+
+    def unpack_file(self, file_path: str) -> bytearray:
+        """Unpack a file from the archive"""
+        if self._file_handle is None:
+            raise ValueError("Archive file handle is not open")
+
+        entry = self._entries.get(file_path)
+        if entry is None:
+            raise FileNotFoundError(f"File '{file_path}' not found in archive entries")
+
+        data = bytearray(entry.original_size)
+        self._file_handle.seek(entry.data_offset, io.SEEK_SET)
+        buffer_pos = 0
+        block_count = 0
+
+        for block_size in entry.block_sizes:
+            if block_size == 0:
+                block_size = self._MAX_BLOCK_SIZE
+
+            block_data = self._file_handle.read(block_size)
+            if len(block_data) < block_size:
+                raise EOFError("Unexpected EOF reading data block")
+
+            is_last_block = (block_count == len(entry.block_sizes) - 1)
+            remaining_size = entry.original_size % self._MAX_BLOCK_SIZE
+
+            if (block_size == self._MAX_BLOCK_SIZE or (is_last_block and block_size == remaining_size)):
+                data[buffer_pos:buffer_pos + block_size] = block_data
+                buffer_pos += block_size
+            else:
+                decompressed_data = zlib.decompress(block_data)
+                decompressed_size = len(decompressed_data)
+                data[buffer_pos:buffer_pos + decompressed_size] = decompressed_data
+                buffer_pos += decompressed_size
+
+            block_count += 1
+
+        return data
+
+    @staticmethod
+    def _read_null_string_lower(data: bytes, offset: int) -> str:
+        """Read a null-terminated string from byte data and convert to lowercase."""
+        end = data.find(b"\0", offset)
+        if end == -1:
+            end = len(data)
+
+        return data[offset:end].decode("utf-8", errors = "replace").lower()
+
+def get_archives(folder: Path) -> list[Path]:
+    """Return a list of all archives in the given folder."""
+    if not folder.exists() or not folder.is_dir():
+        return []
+
+    return list(folder.glob("*.vbf"))

--- a/ff12/Archive/View.py
+++ b/ff12/Archive/View.py
@@ -1,0 +1,138 @@
+from pathlib import Path
+
+from PyQt6.QtCore import QCoreApplication, QModelIndex, QStandardPaths, Qt
+from PyQt6.QtGui import QAction
+from PyQt6.QtWidgets import QFileDialog, QMenu, QMessageBox, QProgressDialog, QTreeView, QWidget
+
+from .Model import ArchiveColumn, TreeNode
+
+class ArchiveView(QTreeView):
+    def __init__(self, parent: QWidget | None):
+        super().__init__(parent)
+
+        self.setRootIndex(QModelIndex())
+        self.setAlternatingRowColors(True)
+        self.setSortingEnabled(True)
+        self.setSelectionMode(QTreeView.SelectionMode.ExtendedSelection)
+        self.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
+        self.customContextMenuRequested.connect(self._show_context_menu)
+        self._last_export_dir = None
+        self._model = None
+
+    def _setup_view(self):
+        """Setup view appearance and default sorting."""
+        if self._model is None:
+            return
+
+        self.setColumnWidth(ArchiveColumn.NAME, 290)
+        self.setColumnWidth(ArchiveColumn.TYPE, 90)
+        self.setColumnWidth(ArchiveColumn.SIZE, 90)
+        self.sortByColumn(ArchiveColumn.NAME, Qt.SortOrder.AscendingOrder)
+
+    def setModel(self, model):
+        """Setup view after model is set."""
+        super().setModel(model)
+        self._model = model
+        self._setup_view()
+
+    def _show_context_menu(self, position):
+        """Show context menu at the given position."""
+        if self._model is None:
+            return
+
+        menu = QMenu(self)
+
+        selected_indexes = self._get_selected_indexes()
+        if selected_indexes:
+            export_action = QAction("Export", self)
+            export_action.triggered.connect(lambda: self._export_selection(selected_indexes))
+            menu.addAction(export_action)
+
+        if menu.actions():
+            menu.exec(self.mapToGlobal(position))
+
+    def _export_selection(self, indexes):
+        start_dir = self._last_export_dir or QStandardPaths.writableLocation(
+            QStandardPaths.StandardLocation.DesktopLocation
+        )
+
+        export_dir = QFileDialog.getExistingDirectory(self, "Choose Export Directory", start_dir)
+        if not export_dir:
+            return
+
+        self._last_export_dir = export_dir
+        export_path = Path(export_dir)
+
+        files_to_export = self._get_selected_files(indexes)
+        if not files_to_export:
+            QMessageBox.information(self, "Export", "No files to export.")
+            return
+
+        progress = QProgressDialog("Exporting files...", "Cancel", 0, len(files_to_export), self)
+        progress.setWindowModality(Qt.WindowModality.WindowModal)
+        progress.show()
+
+        exported_count = 0
+        failed_files = []
+
+        with self._model._reader as reader:
+            for i, file_node in enumerate(files_to_export):
+                if progress.wasCanceled():
+                    break
+
+                progress.setLabelText(f"Exporting: {file_node.name}")
+                progress.setValue(i)
+                QCoreApplication.processEvents()
+
+                try:
+                    relative_path = file_node.path()
+                    output_file = export_path / Path(relative_path)
+                    output_file.parent.mkdir(parents = True, exist_ok = True)
+
+                    data = reader.unpack_file(relative_path)
+                    with open(output_file, 'wb') as file:
+                        file.write(data)
+
+                    exported_count += 1
+                except Exception as e:
+                    failed_files.append(f"{relative_path} ({str(e)})")
+
+        progress.close()
+        if failed_files:
+            log_path = export_path / "export.log"
+            with open(log_path, "w", encoding = "utf-8") as log_file:
+                log_file.write("\n".join(failed_files))
+
+            total_count = len(files_to_export)
+            fail_count = len(failed_files)
+            QMessageBox.warning(self, "Export Complete",
+                                f"Only {total_count - fail_count} of {total_count} files were exported successfully.\n"
+                                f"See log for details: {log_path}")
+        else:
+            QMessageBox.information(self, "Export Complete",
+                                    f"Successfully exported {exported_count} file(s) to:\n{export_path}")
+
+    def _get_selected_indexes(self) -> list[QModelIndex]:
+        indexes = self.selectionModel().selectedIndexes()
+
+        rows = {}
+        for index in indexes:
+            if index.column() == 0:
+                rows[index.row()] = index
+
+        return list(rows.values())
+
+    def _get_selected_files(self, indexes) -> list[TreeNode]:
+        files = []
+        def collect(node):
+            if node.is_dir:
+                for child in node.children:
+                    collect(child)
+            else:
+                files.append(node)
+
+        for index in indexes:
+            node = self._model.get_node(index)
+            if node:
+                collect(node)
+        return files

--- a/ff12/Archive/Widget.py
+++ b/ff12/Archive/Widget.py
@@ -1,0 +1,106 @@
+from pathlib import Path
+
+from PyQt6.QtCore import Qt
+from PyQt6.QtWidgets import QComboBox, QHBoxLayout, QLabel, QSizePolicy, QVBoxLayout, QWidget
+
+from .Loader import ArchiveLoader
+from .Model import ArchiveModel
+from .Reader import ArchiveReader, get_archives
+from .View import ArchiveView
+
+class ArchiveContainerWidget(QWidget):
+    def __init__(self, content_path: Path, parent: QWidget | None = None):
+        super().__init__(parent)
+        self._content_path = content_path
+        self._current_content: ArchiveContentWidget | None = None
+        self._loader = None
+
+        v_layout = QVBoxLayout(self)
+        v_layout.setAlignment(Qt.AlignmentFlag.AlignTop)
+
+        h_layout = QHBoxLayout()
+        label = QLabel("File")
+        h_layout.addWidget(label)
+
+        self._combo_box = QComboBox(self)
+        self._combo_box.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+        h_layout.addWidget(self._combo_box)
+        v_layout.addLayout(h_layout)
+
+        self._content = QVBoxLayout()
+        v_layout.addLayout(self._content)
+
+        self._combo_box.currentIndexChanged.connect(self._load_selected)
+
+    def _reset_combo_box(self):
+        self._combo_box.blockSignals(True)
+        self._combo_box.clear()
+        for p in sorted(get_archives(self._content_path)):
+            self._combo_box.addItem(p.name, userData = p)
+        self._combo_box.blockSignals(False)
+
+    def _clear_current_content(self):
+        if self._loader and self._loader.isRunning():
+            self._loader.finished.disconnect()
+            self._loader.error.disconnect()
+            self._loader.quit()
+            self._loader = None
+
+        if self._current_content:
+            self._current_content.setParent(None)
+            self._current_content.deleteLater()
+            self._current_content = None
+
+    def _load_selected(self):
+        archive_path: Path = self._combo_box.currentData()
+        if not archive_path:
+            return
+
+        self._clear_current_content()
+        self._current_content = ArchiveContentWidget()
+        self._content.addWidget(self._current_content)
+
+        self._loader = ArchiveLoader(archive_path)
+        self._loader.finished.connect(self._on_load_finished_callback)
+        self._loader.error.connect(self._on_load_error_callback)
+        self._loader.start()
+
+    def _on_load_finished_callback(self, reader: ArchiveReader):
+        """Called when archive loading is complete."""
+        if self._current_content:
+            self._current_content.load_data(reader)
+
+        if self._loader:
+            self._loader.deleteLater()
+            self._loader = None
+
+    def _on_load_error_callback(self, error_msg):
+        """Called when archive loading fails."""
+        if self._loader:
+            self._loader.deleteLater()
+            self._loader = None
+
+    def showEvent(self, event):
+        super().showEvent(event)
+        self._reset_combo_box()
+        if self._combo_box.count() > 0 and not self._current_content:
+            self._load_selected()
+
+    def hideEvent(self, event):
+        super().hideEvent(event)
+        self._clear_current_content()
+
+class ArchiveContentWidget(QWidget):
+    def __init__(self, parent: QWidget | None = None):
+        super().__init__(parent)
+
+        self._model = ArchiveModel()
+        self._view = ArchiveView(self)
+        self._view.setModel(self._model)
+
+        self._layout = QVBoxLayout(self)
+        self._layout.addWidget(self._view)
+        self.setLayout(self._layout)
+
+    def load_data(self, reader: ArchiveReader):
+        self._model.set_data(reader)

--- a/game_ff12.py
+++ b/game_ff12.py
@@ -205,45 +205,46 @@ class FF12TZAGame(BasicGame):
         else:
             qInfo(f"Set Steam ID to '{last_steam_id}'.")
 
-    def _on_user_interface_initialized_callback(
-            self,
-            window: QMainWindow
-    ):
-        current_game = self._organizer.managedGame()
-        if current_game is not self:
+    def _on_user_interface_initialized_callback(self, window: QMainWindow):
+        if self._organizer.managedGame() is not self:
             return
 
-        if settings_manager().get_setting(SettingName.DISABLE_AUTO_UPDATES) is not True:
+        self._check_for_update(window)
 
-            remind_time = settings_manager().get_setting(SettingName.SKIP_UPDATE_UNTIL_DATE)
-            now_secs = int(QDateTime.currentDateTime().toSecsSinceEpoch())
+    def _check_for_update(self, window: QMainWindow):
+        if settings_manager().get_setting(SettingName.DISABLE_AUTO_UPDATES) is True:
+            return
 
-            if remind_time and now_secs is not None and remind_time > now_secs:
-                return
+        remind_time = settings_manager().get_setting(SettingName.SKIP_UPDATE_UNTIL_DATE)
+        now_secs = int(QDateTime.currentDateTime().toSecsSinceEpoch())
 
-            update_checker = UpdateChecker(
-                "FF12 Plugin",
-                "FF12-Modding", "FF12-MO2-Plugin",
-                VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH,
-                VERSION_RELEASE_TYPE,
-                window,
-                update_targets=["game_ff12.py", "ff12"],
-                remove_targets=["ff12"],
-                skip_version=settings_manager().get_setting(SettingName.SKIP_UPDATE_VERSION),
-                plugin_dir=os.path.dirname(__file__),
-            )
-            # We're using non-modal dialogs, so we have to use callbacks to clear settings
-            def on_update_installed():
-                settings_manager().set_setting(SettingName.SKIP_UPDATE_VERSION, "v0.0.0")
-                settings_manager().set_setting(SettingName.SKIP_UPDATE_UNTIL_DATE, 0)
+        if remind_time and now_secs is not None and remind_time > now_secs:
+            return
 
-            def on_version_skipped(version: str):
-                settings_manager().set_setting(SettingName.SKIP_UPDATE_VERSION, version)
+        update_checker = UpdateChecker(
+            "FF12 Plugin",
+            "FF12-Modding", "FF12-MO2-Plugin",
+            VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH,
+            VERSION_RELEASE_TYPE,
+            window,
+            update_targets=["game_ff12.py", "ff12"],
+            remove_targets=["ff12"],
+            skip_version=settings_manager().get_setting(SettingName.SKIP_UPDATE_VERSION),
+            plugin_dir=os.path.dirname(__file__),
+        )
 
-            def on_update_remind(remind_time: int):
-                settings_manager().set_setting(SettingName.SKIP_UPDATE_UNTIL_DATE, remind_time)
+        # We're using non-modal dialogs, so we have to use callbacks to clear settings.
+        def on_update_installed():
+            settings_manager().set_setting(SettingName.SKIP_UPDATE_VERSION, "v0.0.0")
+            settings_manager().set_setting(SettingName.SKIP_UPDATE_UNTIL_DATE, 0)
 
-            update_checker.on_update_installed(on_update_installed)
-            update_checker.on_version_skipped(on_version_skipped)
-            update_checker.on_update_remind(on_update_remind)
-            update_checker.check_for_update()
+        def on_version_skipped(version: str):
+            settings_manager().set_setting(SettingName.SKIP_UPDATE_VERSION, version)
+
+        def on_update_remind(remind_time: int):
+            settings_manager().set_setting(SettingName.SKIP_UPDATE_UNTIL_DATE, remind_time)
+
+        update_checker.on_update_installed(on_update_installed)
+        update_checker.on_version_skipped(on_version_skipped)
+        update_checker.on_update_remind(on_update_remind)
+        update_checker.check_for_update()

--- a/game_ff12.py
+++ b/game_ff12.py
@@ -16,7 +16,7 @@ from PyQt6.QtCore import (
     qInfo,
 )
 
-from PyQt6.QtWidgets import QMainWindow
+from PyQt6.QtWidgets import QMainWindow, QTabWidget
 
 from ..basic_features import BasicLocalSavegames
 from ..basic_features.basic_save_game_info import BasicGameSaveGameInfo
@@ -27,6 +27,7 @@ from .ff12.ModDataChecker import FF12ModDataChecker
 from .ff12.SaveGame import FF12SaveGame, getSaveMetadata
 from .ff12.SettingsManager import SettingsManager, settings_manager, SettingName
 from .ff12.SteamHelper import get_last_logged_steam_id
+from .ff12.Archive.Widget import ArchiveContainerWidget
 
 class FF12TZAGame(BasicGame):
     Name = "Final Fantasy XII TZA Support Plugin"
@@ -38,6 +39,8 @@ class FF12TZAGame(BasicGame):
     GameDataPath = "%GAME_PATH%"
     GameSteamId = 595520
     GameSavesDirectory = "%GAME_DOCUMENTS%"
+
+    _archives_tab: ArchiveContainerWidget
 
     def __init__(self):
         super().__init__()
@@ -209,7 +212,17 @@ class FF12TZAGame(BasicGame):
         if self._organizer.managedGame() is not self:
             return
 
+        self._add_archives_tab(window)
         self._check_for_update(window)
+
+    def _add_archives_tab(self, window: QMainWindow):
+        tab_widget: QTabWidget = window.findChild(QTabWidget, "tabWidget")
+        if not tab_widget:
+            return
+
+        game_path = Path(self.gameDirectory().absolutePath())
+        self._archives_tab = ArchiveContainerWidget(game_path)
+        tab_widget.addTab(self._archives_tab, "Archives")
 
     def _check_for_update(self, window: QMainWindow):
         if settings_manager().get_setting(SettingName.DISABLE_AUTO_UPDATES) is True:


### PR DESCRIPTION
## Archives Tab

Adds a new archives tab that lets you browse and extract files from .vbf files in the game directory.

### Features
- Browse archive contents like in a file browser.
- Sort by name, type, or file size.
- Right-click to export selected directories or files.
- Progress bar shows extraction status for large operations.
- Automatically finds all .vbf files in the game directory.
- Switch between different archives using the drop-down menu.
- Archive is loaded in the background, so the UI doesn't freeze on large ones.

### Issues / Notes
- The drop-down menu can still freeze for less than a second while a tree view is being build for a large archive.
- Tree view properties like expanded directories, column widths, and more are reset every time the archives tab is opened.
- The top grey border of the tree view is always missing where as the left one is missing based on MO2 window size (latter happens for the "data" tab too).